### PR TITLE
Fix missing padding in page layout

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -13,7 +13,7 @@ function AppLayout({ children }: AppLayoutProps) {
   const notif = useRecoilValue(pageNotificationState);
 
   return (
-    <Stack height='100%'>
+    <Stack>
       <NavBar />
       <Snackbar
         open={notif.open}

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -11,7 +11,6 @@ function PageLayout({ children, maxWidth }: PageLayoutProps) {
     <Box
       component='main'
       sx={{
-        height: '100%',
         width: '100%',
         maxWidth: maxWidth ?? 'lg',
         marginX: 'auto',

--- a/src/main.css
+++ b/src/main.css
@@ -3,3 +3,9 @@ body,
 #root {
   height: 100%;
 }
+
+html,
+body,
+#root {
+  min-height: 100%;
+}


### PR DESCRIPTION
## Description

Fix missing padding - the padding in the bottom of PageLayout was not applied because of incorrect height
