### PR TITLE
Fix broken registration form & autofill

### DIFF
--- a/src/data/formData/user.tsx
+++ b/src/data/formData/user.tsx
@@ -46,14 +46,26 @@ interface UserFormFieldsProps {
 export function UserFormFields({ showRegisterFields = false }: UserFormFieldsProps) {
   return (
     <>
-      {showRegisterFields && <FormikTextField name='email' label='E-mail' type='email' />}
+      {showRegisterFields && (
+        <FormikTextField name='email' label='E-mail' type='email' autoComplete='email' />
+      )}
       <FormikTextField name='nickname' label='Nazwa użytkownika' />
       <FormikTextField name='name' label='Imię' />
       <FormikTextField name='surname' label='Nazwisko' />
       {showRegisterFields && (
         <>
-          <FormikTextField name='password' label='Hasło' type='password' />
-          <FormikTextField name='repeatPassword' label='Powtórz hasło' type='password' />
+          <FormikTextField
+            name='password'
+            label='Hasło'
+            type='password'
+            autoComplete='new-password'
+          />
+          <FormikTextField
+            name='repeatPassword'
+            label='Powtórz hasło'
+            type='password'
+            autoComplete='new-password'
+          />
         </>
       )}
       <FormikSwitch

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -12,7 +12,7 @@ const formikInitialValues = {
 
 const formFields = (
   <>
-    <FormikTextField name='email' label='E-mail' type='email' />
+    <FormikTextField name='email' label='E-mail' type='email' autoComplete='email' />
     <FormikTextField name='password' label='Hasło' type='password' />
   </>
 );

--- a/src/pages/Register/RegisterForm.tsx
+++ b/src/pages/Register/RegisterForm.tsx
@@ -23,8 +23,8 @@ const formikInitialValues = {
 function RegisterForm() {
   const { isLoading, error, mutate } = useRegister();
 
-  const handleSubmit = async (values: RegisterFormValues) => {
-    delete values.repeatPassword;
+  const handleSubmit = async (formValues: RegisterFormValues) => {
+    const { repeatPassword: _repeatPassword, ...values } = formValues;
     const avatarImage =
       values.avatarImage !== null ? await toBase64(values.avatarImage) : null;
     const payload: PostUserDetails = { ...values, avatarImage };


### PR DESCRIPTION
## Description

Fix broken registration form & autofill

## Added/modified functionality

- fix broken registration form -- previously, when registration did not succeed, the `repeatPassword` field was removed so the form was broken
- add new-password hints -- now, the browser does not autofill the registartion form with existing credentials & it suggests an autogenerated strong password
- add autocomplete hints -- now, the email (and not username) is saved by the browser and it is correctly autofilled on login

## Screenshots

![image](https://github.com/IO2-2023-JB/team_10_frontend/assets/92390086/fe308e1d-ef41-41cd-96c6-018362d67814)

